### PR TITLE
Prune/Retention Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ rsync:
   #override_global_excluded: true
   #override_global_args:     true
 
+# FIXME needs more details (
+retention:
+  daily:    int       # number of daily backups to keep
+  weekly:   int       # number of weekly backups to keep
+  monthly:  int       # number of monthly backups to keep
+  yearly:   int       # number of yearly backups to keep
+
 # Inline scripts executed on the remote host before and after rsyncing,
 # and before any `pre.*.sh` and/or `post.*.sh` scripts for this host.
 pre_script:  string
@@ -222,6 +229,11 @@ rsync:
   - "--hard-links"
   - "--block-size=2048"
   - "--recursive"
+retention:
+  daily: 14
+  weekly: 4
+  monthly: 6
+  yearly: 5
 ```
 
 # Copyright

--- a/app/prune.go
+++ b/app/prune.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/digineo/zackup/config"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	patterns = map[string]string{
+		"daily":   "2006-01-02",
+		"weekly":  "", // See special case in keepers()
+		"monthly": "2006-01",
+		"yearly":  "2006",
+	}
+)
+
+type snapshot struct {
+	Ds   string    // Snapshot dataset name "backups/foo@RFC3339"
+	Time time.Time // Parsed timestamp from the dataset name
+}
+
+func PruneSnapshots(job *config.JobConfig) {
+	var host = job.Host()
+
+	// Set defaults if config is not set
+	if job.Retention == nil {
+		job.Retention = &config.RetentionConfig{
+			Daily:   100000,
+			Weekly:  100000,
+			Monthly: 100000,
+			Yearly:  100000,
+		}
+	}
+
+	// This catches any gaps in the config
+	if job.Retention.Daily == 0 {
+		job.Retention.Daily = 100000
+	}
+	if job.Retention.Weekly == 0 {
+		job.Retention.Weekly = 100000
+	}
+	if job.Retention.Monthly == 0 {
+		job.Retention.Monthly = 100000
+	}
+	if job.Retention.Yearly == 0 {
+		job.Retention.Yearly = 100000
+	}
+
+	// FIXME probably should iterate over a list instead here
+	for _, snapshot := range listKeepers(host, "daily", job.Retention.Daily) {
+		log.WithFields(logrus.Fields{
+			"snapshot": snapshot,
+			"period":   "daily",
+		}).Debug("keeping snapshot")
+	}
+	for _, snapshot := range listKeepers(host, "weekly", job.Retention.Weekly) {
+		log.WithFields(logrus.Fields{
+			"snapshot": snapshot,
+			"period":   "weekly",
+		}).Debug("keeping snapshot")
+	}
+	for _, snapshot := range listKeepers(host, "monthly", job.Retention.Monthly) {
+		log.WithFields(logrus.Fields{
+			"snapshot": snapshot,
+			"period":   "monthly",
+		}).Debug("keeping snapshot")
+	}
+	for _, snapshot := range listKeepers(host, "yearly", job.Retention.Yearly) {
+		log.WithFields(logrus.Fields{
+			"snapshot": snapshot,
+			"period":   "yearly",
+		}).Debug("keeping snapshot")
+	}
+
+	// TODO subtract keepers from the list of snapshots and rm -rf them
+}
+
+// listKeepers returns a list of snapshot that are not subject to deletion
+// for a given host, pattern, and keep_count.
+func listKeepers(host string, pattern string, keep_count uint) []snapshot {
+	var keepers []snapshot
+	var last string
+
+	for _, snapshot := range listSnapshots(host) {
+		var period string
+
+		// Weekly is special because golang doesn't have support for "week number in year"
+		// in Time.Format strings.
+		if pattern == "weekly" {
+			year, week := snapshot.Time.Local().ISOWeek()
+			period = fmt.Sprintf("%d-%d", year, week)
+		} else {
+			period = snapshot.Time.Local().Format(patterns[pattern])
+		}
+
+		if period != last {
+			last = period
+			keepers = append(keepers, snapshot)
+
+			if uint(len(keepers)) == keep_count {
+				break
+			}
+		}
+	}
+
+	return keepers
+}
+
+// listSnapshots calls out to ZFS for a list of snapshots for a given host.
+// Returned data will be sorted by time, most recent first.
+func listSnapshots(host string) []snapshot {
+	var snapshots []snapshot
+
+	ds := newDataset(host)
+
+	args := []string{
+		"list",
+		"-H",         // no field headers in output
+		"-o", "name", // only name field
+		"-t", "snapshot", // type snapshot
+		ds.Name,
+	}
+	o, e, err := execProgram("zfs", args...)
+	if err != nil {
+		f := appendStdlogs(logrus.Fields{
+			logrus.ErrorKey: err,
+			"prefix":        "zfs",
+			"command":       append([]string{"zfs"}, args...),
+		}, o, e)
+		log.WithFields(f).Errorf("executing zfs list failed")
+	}
+
+	for _, ss := range strings.Fields(o.String()) {
+		ts, err := time.Parse(time.RFC3339, strings.Split(ss, "@")[1])
+
+		if err != nil {
+			log.WithField("snapshot", ss).Error("Unable to parse timestamp from snapshot")
+			continue
+		}
+
+		snapshots = append(snapshots, snapshot{
+			Ds:   ss,
+			Time: ts,
+		})
+	}
+
+	// ZFS list _should_ be in chronological order but just in case ...
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Time.After(snapshots[j].Time)
+	})
+
+	return snapshots
+}

--- a/app/prune.go
+++ b/app/prune.go
@@ -20,7 +20,7 @@ var (
 )
 
 type snapshot struct {
-	Ds   string    // Snapshot dataset name "backups/foo@RFC3339"
+	Name string    // Snapshot dataset name "backups/foo@RFC3339"
 	Time time.Time // Parsed timestamp from the dataset name
 }
 
@@ -138,7 +138,7 @@ func listSnapshots(host string) []snapshot {
 		}
 
 		snapshots = append(snapshots, snapshot{
-			Ds:   ss,
+			Name: ss,
 			Time: ts,
 		})
 	}

--- a/app/prune.go
+++ b/app/prune.go
@@ -112,6 +112,7 @@ func listSnapshots(host string) []snapshot {
 
 	args := []string{
 		"list",
+		"-r",         // recursive
 		"-H",         // no field headers in output
 		"-o", "name", // only name field
 		"-t", "snapshot", // type snapshot

--- a/app/prune.go
+++ b/app/prune.go
@@ -24,10 +24,12 @@ type snapshot struct {
 	Time time.Time // Parsed timestamp from the dataset name
 }
 
+// FIXME PruneSnapshots does not actually perform any destructive operations
+// on your datasets at this time.
 func PruneSnapshots(job *config.JobConfig) {
 	var host = job.Host()
 
-	// Set defaults if config is not set
+	// Defaults: if config is not set
 	if job.Retention == nil {
 		job.Retention = &config.RetentionConfig{
 			Daily:   100000,
@@ -37,7 +39,7 @@ func PruneSnapshots(job *config.JobConfig) {
 		}
 	}
 
-	// This catches any gaps in the config
+	// Defaults: catch any gaps in the config
 	if job.Retention.Daily == 0 {
 		job.Retention.Daily = 100000
 	}
@@ -51,30 +53,20 @@ func PruneSnapshots(job *config.JobConfig) {
 		job.Retention.Yearly = 100000
 	}
 
-	// FIXME probably should iterate over a list instead here
-	for _, snapshot := range listKeepers(host, "daily", job.Retention.Daily) {
-		log.WithFields(logrus.Fields{
-			"snapshot": snapshot,
-			"period":   "daily",
-		}).Debug("keeping snapshot")
+	var keep_counts = map[string]uint{
+		"daily":   job.Retention.Daily,
+		"weekly":  job.Retention.Weekly,
+		"monthly": job.Retention.Monthly,
+		"yearly":  job.Retention.Yearly,
 	}
-	for _, snapshot := range listKeepers(host, "weekly", job.Retention.Weekly) {
-		log.WithFields(logrus.Fields{
-			"snapshot": snapshot,
-			"period":   "weekly",
-		}).Debug("keeping snapshot")
-	}
-	for _, snapshot := range listKeepers(host, "monthly", job.Retention.Monthly) {
-		log.WithFields(logrus.Fields{
-			"snapshot": snapshot,
-			"period":   "monthly",
-		}).Debug("keeping snapshot")
-	}
-	for _, snapshot := range listKeepers(host, "yearly", job.Retention.Yearly) {
-		log.WithFields(logrus.Fields{
-			"snapshot": snapshot,
-			"period":   "yearly",
-		}).Debug("keeping snapshot")
+
+	for bucket, keep_count := range keep_counts {
+		for _, snapshot := range listKeepers(host, bucket, keep_count) {
+			log.WithFields(logrus.Fields{
+				"snapshot": snapshot,
+				"bucket":   bucket,
+			}).Debug("keeping snapshot")
+		}
 	}
 
 	// TODO subtract keepers from the list of snapshots and rm -rf them
@@ -82,7 +74,7 @@ func PruneSnapshots(job *config.JobConfig) {
 
 // listKeepers returns a list of snapshot that are not subject to deletion
 // for a given host, pattern, and keep_count.
-func listKeepers(host string, pattern string, keep_count uint) []snapshot {
+func listKeepers(host string, bucket string, keep_count uint) []snapshot {
 	var keepers []snapshot
 	var last string
 
@@ -90,12 +82,12 @@ func listKeepers(host string, pattern string, keep_count uint) []snapshot {
 		var period string
 
 		// Weekly is special because golang doesn't have support for "week number in year"
-		// in Time.Format strings.
-		if pattern == "weekly" {
+		// as Time.Format string pattern.
+		if bucket == "weekly" {
 			year, week := snapshot.Time.Local().ISOWeek()
 			period = fmt.Sprintf("%d-%d", year, week)
 		} else {
-			period = snapshot.Time.Local().Format(patterns[pattern])
+			period = snapshot.Time.Local().Format(patterns[bucket])
 		}
 
 		if period != last {

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/digineo/zackup/app"
+	"github.com/spf13/cobra"
+)
+
+// pruneCmd represents the prune command
+var pruneCmd = &cobra.Command{
+	Use:   "prune [host [...]]",
+	Short: "Prunes backups per-host ZFS dataset",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			args = tree.Hosts()
+		}
+
+		for _, host := range args {
+			job := tree.Host(host)
+			if job == nil {
+				log.WithField("prune", host).Warn("unknown host, ignoring")
+				continue
+			}
+
+			app.PruneSnapshots(job)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pruneCmd)
+}

--- a/config/job.go
+++ b/config/job.go
@@ -21,10 +21,10 @@ type SSHConfig struct {
 
 // RetentionConfig holds backup retention periods
 type RetentionConfig struct {
-	Daily   uint `yaml:"daily"`   // defaults to 1000000
-	Weekly  uint `yaml:"weekly"`  // defaults to 1000000
-	Monthly uint `yaml:"monthly"` // defaults to 1000000
-	Yearly  uint `yaml:"yearly"`  // defaults to 1000000
+	Daily   *int `yaml:"daily"`   // defaults to infinite
+	Weekly  *int `yaml:"weekly"`  // defaults to infinite
+	Monthly *int `yaml:"monthly"` // defaults to infinite
+	Yearly  *int `yaml:"yearly"`  // defaults to infinite
 }
 
 // Host returns the hostname for this job.
@@ -73,16 +73,16 @@ func (j *JobConfig) mergeGlobals(globals *JobConfig) {
 			dup := *globals.Retention
 			j.Retention = &dup
 		} else {
-			if j.Retention.Daily == 0 {
+			if j.Retention.Daily == nil {
 				j.Retention.Daily = globals.Retention.Daily
 			}
-			if j.Retention.Weekly == 0 {
+			if j.Retention.Weekly == nil {
 				j.Retention.Weekly = globals.Retention.Weekly
 			}
-			if j.Retention.Monthly == 0 {
+			if j.Retention.Monthly == nil {
 				j.Retention.Monthly = globals.Retention.Monthly
 			}
-			if j.Retention.Yearly == 0 {
+			if j.Retention.Yearly == nil {
 				j.Retention.Yearly = globals.Retention.Yearly
 			}
 		}

--- a/config/job.go
+++ b/config/job.go
@@ -4,8 +4,9 @@ package config
 type JobConfig struct {
 	host string
 
-	SSH   *SSHConfig   `yaml:"ssh"`
-	RSync *RsyncConfig `yaml:"rsync"`
+	SSH       *SSHConfig       `yaml:"ssh"`
+	RSync     *RsyncConfig     `yaml:"rsync"`
+	Retention *RetentionConfig `yaml:"retention"`
 
 	PreScript  Script `yaml:"pre_script"`  // from yaml file
 	PostScript Script `yaml:"post_script"` // from yaml file
@@ -16,6 +17,14 @@ type SSHConfig struct {
 	User    string `yaml:"user"`    // defaults to "root"
 	Port    uint16 `yaml:"port"`    // defaults to 22
 	Timeout *uint  `yaml:"timeout"` // number of seconds, defaults to 15
+}
+
+// RetentionConfig holds backup retention periods
+type RetentionConfig struct {
+	Daily   uint `yaml:"daily"`   // defaults to 1000000
+	Weekly  uint `yaml:"weekly"`  // defaults to 1000000
+	Monthly uint `yaml:"monthly"` // defaults to 1000000
+	Yearly  uint `yaml:"yearly"`  // defaults to 1000000
 }
 
 // Host returns the hostname for this job.
@@ -55,6 +64,26 @@ func (j *JobConfig) mergeGlobals(globals *JobConfig) {
 			}
 			if !j.RSync.OverrideGlobalArguments {
 				j.RSync.Arguments = append(j.RSync.Arguments, globals.RSync.Arguments...)
+			}
+		}
+	}
+
+	if globals.Retention != nil {
+		if j.Retention == nil {
+			dup := *globals.Retention
+			j.Retention = &dup
+		} else {
+			if j.Retention.Daily == 0 {
+				j.Retention.Daily = globals.Retention.Daily
+			}
+			if j.Retention.Weekly == 0 {
+				j.Retention.Weekly = globals.Retention.Weekly
+			}
+			if j.Retention.Monthly == 0 {
+				j.Retention.Monthly = globals.Retention.Monthly
+			}
+			if j.Retention.Yearly == 0 {
+				j.Retention.Yearly = globals.Retention.Yearly
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	gopkg.in/gemnasium/logrus-graylog-hook.v2 v2.0.7
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/testdata/globals.yml
+++ b/testdata/globals.yml
@@ -4,6 +4,12 @@ ssh:
   port: 22
   identity_file: /etc/zackup/id_rsa.pub
 
+retention:
+  daily: 14
+  weekly: 4
+  monthly: 6
+  yearly: 5
+
 rsync:
   included:
   - /etc


### PR DESCRIPTION
Closes #2 

This is a work in progress.

This uses a super simple algorithm to determine with snapshots to keep, see `listKeepers` function.

The `PruneSnapshots` command currently does not perform any destructive operations on your ZFS datasets. The debug logging is how I've been testing. I want to write some tests but I wanted to get this out there for more discussion around the `listKeepers` function.

(Side note: I don't know why commit f9b040a is showing up in this PR since it's already in master ???)


